### PR TITLE
Allows calling functions w/ `callEval` with explicit strings, Rctx macro

### DIFF
--- a/README.org
+++ b/README.org
@@ -113,6 +113,31 @@ doAssert R.hello("User").to(string) == "Hello User"
 
 That covers the most basic functionality in place so far.
 
+*** =Rctx= macro
+
+As mentioned in the previous secton, some function names are weird and
+require the user to use =callEval= directly.
+
+To make calling such functions a bit nicer, there is an =Rctx= macro,
+which allows for directly calling R functions with e.g. dots in their
+names, and also allows for assignments.
+
+#+begin_src nim
+
+let x = @[5, 10, 15]
+let y = @[2.0, 4.0, 6.0]
+
+var df: SEXP
+Rctx:
+  df = data.frame(Col1 = x, Col2 = y)
+  let df2 = data.frame(Col1 = x, Col2 = y)
+  print("Hello from R")
+#+end_src
+where both =df= as well as =df2= will then store an equivalent data
+frame. The last line shows that it's also possible to use this macro
+to avoid the need to discard all R calls.
+
+
 
 ** Trying it out
 

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,8 @@
+* v0.1.2
+- =callEval= now works correctly with strings as function names,
+  e.g. to allow R functions with dots, =data.frame=
+- add a =Rctx= macro, which can be used for more convenient R calls
+  (see README)
 * v0.1.1
 - fix project structure to be nimble installable
 - add changelog

--- a/rnim.nimble
+++ b/rnim.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.1"
+version       = "0.1.2"
 author        = "Vindaar"
 description   = "A library to interface between Nim and R"
 license       = "MIT"

--- a/src/rnim.nim
+++ b/src/rnim.nim
@@ -134,8 +134,10 @@ macro call*(fn: untyped, args: varargs[untyped]): untyped =
   # TODO: copy to Nim type to be able to unprotect R?
   let fnName = block:
     var res: NimNode
-    if fn.kind == nnkIdent: res = fn.toStrLit
-    elif fn.kind == nnkAccQuoted: res = fn[0].toStrLit
+    case fn.kind
+    of nnkIdent: res = fn.toStrLit
+    of nnkStrLit: res = fn
+    of nnkAccQuoted: res = fn[0].toStrLit
     else: res = newLit fn.repr #doAssert false, "Invalid kind of func " & $(fn.kind)
     res
   var callNode = nnkCall.newTree(

--- a/tests/tRfromNim.nim
+++ b/tests/tRfromNim.nim
@@ -1,4 +1,4 @@
-import sequtils
+import sequtils, strutils
 import ../src/rnim
 import unittest
 
@@ -60,3 +60,31 @@ suite "R stdlib function calls":
 suite "R function with … arguments":
   test "Named param after …":
     check R.dotFn(param = "It got back!").to(string) == "It got back!"
+
+suite "Unusual R function names":
+  test "Call function with a . in its name":
+    let a = @[1, 2, 3]
+    let b = @[2, 4, 6]
+    let df = callEval("data.frame", col1 = a, col2 = b)
+    ## TODO: fixup this test. Somehow get the correct string reperesentation for the DF
+    let exp = """
+c(1, 2, 3), c(2, 4, 6)
+"""
+    check R.makeString(df).to(string).strip == exp.strip
+
+suite "Rctx macro":
+  test "Multiple calls":
+    let x = @[5, 10, 15]
+    let y = @[2.0, 4.0, 6.0]
+
+    var df2: SEXP
+    Rctx:
+      let df = data.frame(Col1 = x, Col2 = y)
+      df2 = data.frame(Col1 = x, Col2 = y)
+
+    ## TODO: fix up this test!
+    let exp = """
+c(5, 10, 15), c(2, 4, 6)
+"""
+    check R.makeString(df).to(string).strip == exp.strip
+    check R.makeString(df2).to(string).strip == exp.strip


### PR DESCRIPTION
Fixes an issue where it wasn't correctly possible to call R functions using Nim strings directly (they were handed to R as strings).

Also adds a convenience macro for nicer usage of R calls (to avoid having to discard) and make calls to functions with dots in their names. See the README.