### PR TITLE
fix windows - update lib name and README

### DIFF
--- a/README.org
+++ b/README.org
@@ -141,8 +141,10 @@ to avoid the need to discard all R calls.
 
 ** Trying it out
 
+*** Setup on Linux
+
 To try out the functionality of calling R from Nim, you need to meet a
-few prerequsites:
+few prerequisites:
 - a working R installation _with_ a =libR.so= shared library
 - the shell environment variable =R_HOME= needs to be defined and has
   to point to the directory which contains the full R directory
@@ -162,7 +164,21 @@ few prerequsites:
   /usr/lib/R/lib
   #+end_src
 
-Then just run the test file:
+*** Setup on Windows
+
+On Windows you only need a working R installation _with_ a =R.dll= shared library,
+there is no need to setup =R_HOME= environment variable.
+Example check that =R.dll= is available:
+#+begin_src sh
+where R.dll
+#+end_src
+#+begin_src sh
+C:\Program Files\R\R-4.0.4\bin\x64\R.dll
+#+end_src
+
+*** Test your setup
+
+Run the test file:
 #+begin_src sh
 nim c -r tests/tRfromNim.nim
 #+end_src

--- a/README.org
+++ b/README.org
@@ -173,7 +173,7 @@ few prerequisites.
   structure. That is /not/ the path where the R binary lies! 
   Example setup:
   #+begin_src sh
-  where R
+  where R.dll
   set R_HOME
   #+end_src
   #+begin_src sh

--- a/README.org
+++ b/README.org
@@ -141,10 +141,11 @@ to avoid the need to discard all R calls.
 
 ** Trying it out
 
+To try out the functionality of calling R from Nim, you need to meet a
+few prerequisites.
+
 *** Setup on Linux
 
-To try out the functionality of calling R from Nim, you need to meet a
-few prerequisites:
 - a working R installation _with_ a =libR.so= shared library
 - the shell environment variable =R_HOME= needs to be defined and has
   to point to the directory which contains the full R directory
@@ -166,15 +167,19 @@ few prerequisites:
 
 *** Setup on Windows
 
-On Windows you only need a working R installation _with_ a =R.dll= shared library,
-there is no need to setup =R_HOME= environment variable.
-Example check that =R.dll= is available:
-#+begin_src sh
-where R.dll
-#+end_src
-#+begin_src sh
-C:\Program Files\R\R-4.0.4\bin\x64\R.dll
-#+end_src
+- a working R installation _with_ a =R.dll= shared library
+- the shell environment variable =R_HOME= needs to be defined and has
+  to point to the directory which contains the full R directory
+  structure. That is /not/ the path where the R binary lies! 
+  Example setup:
+  #+begin_src sh
+  where R
+  set R_HOME
+  #+end_src
+  #+begin_src sh
+  C:\Program Files\R\R-4.0.4\bin\x64\R.dll
+  R_HOME=C:\Program Files\R\R-4.0.4
+  #+end_src
 
 *** Test your setup
 

--- a/src/rnim/Rinternals.nim
+++ b/src/rnim/Rinternals.nim
@@ -1,5 +1,9 @@
-const
-  libname* = "libR.so"
+when defined(Windows):
+  const
+    libname* = "R.dll"
+else:
+  const
+    libname* = "libR.so"
 
 import Rinternals_types
 


### PR DESCRIPTION
Hi, thanks for rnim!

I have tested rnim on Windows and this is the easy fix that is required to make it work (just change name of lib to `R.dll` and no need to set `R_HOME`). Only with that (and the shared library available in the path), I am able to run succesfully `nim r tests\tRfromNim.nim`.

I have updated the README accordingly.

I have not tested how to call nim from R.